### PR TITLE
Add AutoGluon training with boolean feature selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # duration_prediction
 Duration Prediction using NHS orthopaedic data
+
+## AutoGluon Modeling
+
+The repository contains two scripts:
+
+- `preprocessing.py` – loads the preprocessed training and test CSV files
+  from Google Drive (or a local path), performs boolean-based feature
+  selection, and reports dataset information.
+- `train_autogluon.py` – trains a lightweight AutoGluon GBM model on the
+  selected features, evaluates regression metrics, and computes
+  permutation feature importance.
+
+Both scripts follow a structure compatible with Google Colab but can also
+run locally.

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,0 +1,182 @@
+"""Data preprocessing utilities for duration prediction.
+
+This module handles data loading and feature selection with a boolean
+mask to enable or disable specific columns. It is designed to mirror
+Google Colab workflows, including optional Drive mounting and runtime
+tracking.
+"""
+
+# Set paths and load df
+
+# ── Block 1: Mount Drive, imports, and runtime setup ──
+
+use_full_train_test = True
+use_sample_train_test = False
+filename = 'duration_prediction_6.0'
+
+from pathlib import Path
+import json
+import os
+import pandas as pd
+
+try:  # Optional Colab imports
+    from google.colab import drive, files  # type: ignore
+    _IN_COLAB = True
+except Exception:  # pragma: no cover - executed outside Colab
+    _IN_COLAB = False
+
+# Runtime control parameters
+runtime_file_name = 'ag_runtime.json'
+total_time_cap = 3 * 3600      # total cap in seconds (3 h)
+chunk_time_limit = 60 * 60     # optional: max time per chunk
+status_interval = 60 * 60      # optional: how often to report status
+
+
+def prepare_datasets(
+    *,
+    use_full_train_test: bool = use_full_train_test,
+    use_sample_train_test: bool = use_sample_train_test,
+    base_dir: str = '/content/drive/MyDrive/UCL_Dissertation',
+    filename: str = filename,
+):
+    """Load training and test data and select columns.
+
+    Parameters
+    ----------
+    use_full_train_test: bool
+        Whether to use the full training and test sets.
+    use_sample_train_test: bool
+        Whether to use sampled training and test sets.
+    base_dir: str
+        Base directory where processed CSVs are stored.
+    filename: str
+        Name used for saving models and runtime files.
+
+    Returns
+    -------
+    dict
+        Contains ``train_data``, ``test_data``, ``model_save_path``,
+        ``runtime_file`` and ``elapsed_time``.
+    """
+
+    # Mount Drive if running in Colab
+    if _IN_COLAB:
+        drive.mount('/content/drive', force_remount=True)  # pragma: no cover
+
+    base_path = Path(base_dir)
+
+    # Define paths to processed data
+    if use_full_train_test:
+        train_data_path = base_path / 'train_data.csv'
+        test_data_path = base_path / 'test_data.csv'
+    elif use_sample_train_test:
+        train_data_path = base_path / 'train_data_sample.csv'
+        test_data_path = base_path / 'test_data_sample.csv'
+    else:
+        raise ValueError("Either use_full_train_test or use_sample_train_test must be True")
+
+    # Load train data (fallback to upload if file not found)
+    if not train_data_path.exists():
+        if _IN_COLAB:
+            print(f"Uploading {train_data_path.name}…")
+            uploaded = files.upload()  # pragma: no cover
+            train_data_path = Path(list(uploaded.keys())[0])
+        else:
+            raise FileNotFoundError(train_data_path)
+    train_data = pd.read_csv(train_data_path)
+
+    # Load test data (fallback to upload if file not found)
+    if not test_data_path.exists():
+        if _IN_COLAB:
+            print(f"Uploading {test_data_path.name}…")
+            uploaded = files.upload()  # pragma: no cover
+            test_data_path = Path(list(uploaded.keys())[0])
+        else:
+            raise FileNotFoundError(test_data_path)
+    test_data = pd.read_csv(test_data_path)
+
+    # ── Remove 'Expected_Length' if present ──
+    for df_name, df in [('train_data', train_data), ('test_data', test_data)]:
+        if 'Expected_Length' in df.columns:
+            df.drop(columns=['Expected_Length'], inplace=True)
+            print(f"▶ Removed 'Expected_Length' from {df_name}")
+
+    # Paths for saving model
+    model_save_path = base_path / 'MyModels' / filename
+    model_save_path.mkdir(parents=True, exist_ok=True)
+
+    # Runtime file
+    runtime_file = model_save_path / runtime_file_name
+
+    # Load or initialize elapsed time
+    if runtime_file.exists():
+        with open(runtime_file, 'r') as f:
+            elapsed_time = json.load(f).get('elapsed_time', 0.0)
+    else:
+        elapsed_time = 0.0
+
+    # Print runtime and data info
+    print(f"▶ Already used {elapsed_time/60:.1f} min of {total_time_cap/3600:.1f} h cap.")
+    print(f"▶ Loaded train data from: {train_data_path} (shape {train_data.shape})")
+    print(f"▶ Loaded test  data from: {test_data_path} (shape {test_data.shape})")
+
+    # Print first line of training data
+    print(train_data.head(1))
+    print(train_data.dtypes)
+
+    # Feature inclusion map (boolean column selection)
+    include_cols = {
+        'Year': True,
+        'Operation_Age': True,
+        'Sex': True,
+        'Ethnic_Category': True,
+        'Anaesthetic_Type_Code': True,
+        'Theatre_Code': True,
+        'Proc_Code_1_Read': True,
+        'Intended_Management': True,
+        'IMD_Score': True,
+        'High_Volume_and_Low_Complexity_Category': True,
+        'High_Volume_and_Low_Complex_or_not': True,
+        'weekday_name': True,
+        'day_working': True,
+        'Season': True,
+        'Pseudo_Consultant': True,
+        'Pseudo_Surgeon': True,
+        'Pseudo_Anaesthetist': True,
+        'Previous_Operation_Length': True,
+        'Previous_Proc_1': True,
+        'Heart_Condition': True,
+        'Hypertension': True,
+        'Obesity': True,
+        'Diabetes': True,
+        'Cancer': True,
+        'Chronic_Kidney_Disease': True,
+        'Surgeon_Anaesthetist_Team': True,
+        'Proc_Code_1_Read_pc1': True,
+        'Previous_Proc_1_pc1': True,
+        'Previous_Operation': True,
+        'is_rare_anaes': True,
+        'is_rare_Proc_Code_1_Read': True,
+        'Proc_Code_1_Read_te_smooth': True,
+        'Anaesthetic_te_smooth': True,
+    }
+
+    cols_to_use = [col for col, use in include_cols.items() if use]
+    cols_to_use.append('Actual_Length')
+
+    train_data = train_data[cols_to_use].copy()
+    test_data = test_data[cols_to_use].copy()
+
+    print(f"▶ Using {len(cols_to_use)-1} features + target:")
+    print(cols_to_use[:-1])
+
+    return {
+        'train_data': train_data,
+        'test_data': test_data,
+        'model_save_path': model_save_path,
+        'runtime_file': runtime_file,
+        'elapsed_time': elapsed_time,
+    }
+
+
+__all__ = ["prepare_datasets"]

--- a/train_autogluon.py
+++ b/train_autogluon.py
@@ -1,0 +1,86 @@
+"""Training script using AutoGluon with boolean feature selection.
+
+This script relies on :mod:`preprocessing` for data loading and column
+selection. It trains a lightweight Gradient Boosting Machine (GBM) model
+and reports common regression metrics along with permutation feature
+importance.
+"""
+
+# Set paths and load df
+
+# ── Block 1: Mount Drive, imports, and runtime setup ──
+
+import json
+import time
+
+from autogluon.tabular import TabularDataset, TabularPredictor
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+from preprocessing import prepare_datasets
+
+# Obtain preprocessed data and paths
+context = prepare_datasets()
+train_data = context['train_data']
+test_data = context['test_data']
+model_save_path = context['model_save_path']
+runtime_file = context['runtime_file']
+elapsed_time = context['elapsed_time']
+
+# Reload data into AutoGluon datasets
+train_data = TabularDataset(train_data)
+test_data = TabularDataset(test_data)
+
+# Force clean model folder
+if model_save_path.exists():
+    import shutil
+    shutil.rmtree(model_save_path)
+    print("▶ Old model directory removed.")
+
+print("▶ Training lightweight model (GBM only, time_limit=60s)...")
+start_time = time.time()
+
+predictor = TabularPredictor(
+    label='Actual_Length',
+    problem_type='regression',
+    eval_metric='mean_absolute_error',
+    path=str(model_save_path),
+    verbosity=2,
+).fit(
+    train_data=train_data,
+    time_limit=60,
+    presets='medium_quality',
+    hyperparameters={'GBM': {}},
+    num_gpus=torch.cuda.device_count() if torch.cuda.is_available() else 0,
+)
+
+train_duration = time.time() - start_time
+print(f"▶ Training time: {train_duration/60:.1f} minutes")
+
+# Update runtime file
+new_elapsed = elapsed_time + train_duration
+with open(runtime_file, 'w') as f:
+    json.dump({'elapsed_time': new_elapsed}, f)
+
+# ── METRICS ──
+print("▶ Evaluating on test set...")
+y_true = test_data['Actual_Length']
+y_pred = predictor.predict(test_data)
+
+mae = mean_absolute_error(y_true, y_pred)
+rmse = mean_squared_error(y_true, y_pred, squared=False)
+r2 = r2_score(y_true, y_pred)
+
+print(f"📊 Test MAE:   {mae:.2f}")
+print(f"📊 Test RMSE:  {rmse:.2f}")
+print(f"📊 Test R²:    {r2:.3f}")
+
+# ── Permutation Importance ──
+print("▶ Calculating permutation feature importance (30% of test set)...")
+subsample_n = int(0.3 * len(test_data))
+fi = predictor.feature_importance(data=test_data, subsample_size=subsample_n)
+
+fi_sorted = fi[['importance']].sort_values(by='importance', ascending=False)
+print(fi_sorted)


### PR DESCRIPTION
## Summary
- add `preprocessing.py` to load datasets and toggle features via boolean map
- introduce `train_autogluon.py` that trains a GBM predictor and reports metrics/feature importance
- document new workflow in README

## Testing
- `python -m py_compile preprocessing.py train_autogluon.py`

------
https://chatgpt.com/codex/tasks/task_e_68949351849c8321ab526d9cac5c6af7